### PR TITLE
Replace deprecated FILTER_SANITIZE_STRING with strip_tags() for PHP 8.1+ compatibility

### DIFF
--- a/wp-config.load.php
+++ b/wp-config.load.php
@@ -43,10 +43,12 @@ function s24_load_environment_config() {
 
     // Define ENV from hostname
     if (!defined('WP_ENV')) {
-        if (isset($_SERVER['HTTP_X_FORWARDED_HOST']) && !empty($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-            $hostname = strtolower(filter_var($_SERVER['HTTP_X_FORWARDED_HOST'], FILTER_SANITIZE_STRING));
+        if (!empty($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+            $hostname = strtolower(trim(strip_tags($_SERVER['HTTP_X_FORWARDED_HOST'])));
+        } elseif (!empty($_SERVER['HTTP_HOST'])) {
+            $hostname = strtolower(trim(strip_tags($_SERVER['HTTP_HOST'])));
         } else {
-            $hostname = strtolower(filter_var($_SERVER['HTTP_HOST'], FILTER_SANITIZE_STRING));
+            throw new Exception("Hostname is not available.");
         }
     }
 


### PR DESCRIPTION
This update replaces the deprecated PHP function FILTER_SANITIZE_STRING. That function is deprecated in PHP 8.1 and removed in PHP 8.3. Instead, the code now uses strip_tags() and trim(), which fixes the issue.